### PR TITLE
Implement finish workout functionality

### DIFF
--- a/app/src/main/java/com/example/gymlocker/ui/activeworkout/ActiveWorkoutScreen.kt
+++ b/app/src/main/java/com/example/gymlocker/ui/activeworkout/ActiveWorkoutScreen.kt
@@ -107,8 +107,7 @@ fun ActiveWorkoutScreen(
                     }
                     Button(
                         onClick = {
-                            viewModel.stopTimer()
-                            // Her kan I evt. lave en "finalize session" hvis I senere vil gemme workout meta
+                            viewModel.finishWorkout()
                             navController.navigate("home") {
                                 popUpTo("home") { inclusive = true }
                             }

--- a/app/src/main/java/com/example/gymlocker/viewmodel/ActiveWorkoutViewModel.kt
+++ b/app/src/main/java/com/example/gymlocker/viewmodel/ActiveWorkoutViewModel.kt
@@ -81,6 +81,58 @@ class ActiveWorkoutViewModel(private val appContext: Context) : ViewModel() {
         currentSessionId = null
     }
 
+    fun finishWorkout() {
+        val sessionId = currentSessionId ?: System.currentTimeMillis().also { currentSessionId = it }
+
+        viewModelScope.launch {
+            // Gem alle indtastede sets (også selvom user ikke trykkede "done")
+            val dateString = SimpleDateFormat(
+                "yyyy-MM-dd HH:mm:ss",
+                Locale.getDefault()
+            ).format(Date())
+
+            val snapshot = _activeExercises.value
+
+            snapshot.forEach { ex ->
+                ex.sets.forEach { set ->
+                    // Kun gem meningsfulde rækker
+                    if (set.reps > 0 && set.weight > 0) {
+                        val existing = exerciseLogDao.getLogForSet(ex.exerciseId, sessionId, set.setNumber)
+
+                        if (existing == null) {
+                            exerciseLogDao.insert(
+                                ExerciseLog(
+                                    exerciseId = ex.exerciseId,
+                                    sessionId = sessionId,
+                                    setNumber = set.setNumber,
+                                    reps = set.reps,
+                                    weight = set.weight,
+                                    date = dateString
+                                )
+                            )
+                        } else {
+                            exerciseLogDao.update(
+                                existing.copy(
+                                    reps = set.reps,
+                                    weight = set.weight,
+                                    date = dateString
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Luk workout (det her er grunden til at "Resume Workout" baren forsvinder)
+            stopTimer()
+            _elapsedTime.value = 0
+            _isWorkoutInProgress.value = false
+            _activeExercises.value = emptyList()
+            currentSessionId = null
+        }
+    }
+
+
     fun formatTime(seconds: Long): String {
         val minutes = seconds / 60
         val remainingSeconds = seconds % 60


### PR DESCRIPTION
Introduced a `finishWorkout()` method in `ActiveWorkoutViewModel` to save the current workout session to the database.

- The `finishWorkout()` function persists all exercise sets with meaningful data (reps > 0 and weight > 0).
- It either inserts new log entries or updates existing ones for the current session.
- After saving, the workout state is reset, including the timer and active exercises.
- The "Finish" button in `ActiveWorkoutScreen` now calls this new `finishWorkout()` method.