### PR TITLE
Bug - Fix display previous set data for active exercises

### DIFF
--- a/app/src/main/java/com/example/gymlocker/data/dao/PerformedSetDao.kt
+++ b/app/src/main/java/com/example/gymlocker/data/dao/PerformedSetDao.kt
@@ -80,4 +80,22 @@ interface PerformedSetDao {
     """
     )
     suspend fun deleteSetByNumber(exerciseLogId: Long, setNumber: Int)
+
+    @Query(
+        """
+    SELECT ps.* FROM performed_set ps
+    JOIN exercise_log el ON el.id = ps.exerciseLogId
+    JOIN workouts w ON w.workoutId = el.workoutId
+    WHERE el.exerciseId = :exerciseId
+      AND ps.setNumber = :setNumber
+      AND (:excludeWorkoutId IS NULL OR w.workoutId != :excludeWorkoutId)
+    ORDER BY w.date DESC
+    LIMIT 1
+    """
+    )
+    suspend fun getLatestSetForExerciseAndNumberExcludingWorkout(
+        exerciseId: Long,
+        setNumber: Int,
+        excludeWorkoutId: Long?
+    ): PerformedSet?
 }

--- a/app/src/main/java/com/example/gymlocker/viewmodel/ActiveWorkoutViewModel.kt
+++ b/app/src/main/java/com/example/gymlocker/viewmodel/ActiveWorkoutViewModel.kt
@@ -141,6 +141,16 @@ class ActiveWorkoutViewModel(private val appContext: Context) : ViewModel() {
             exerciseName = exercise.name
         )
 
+        viewModelScope.launch {
+            val latest = performedSetDao.getLatestSetForExerciseAndNumberExcludingWorkout(
+                exercise.exerciseId,
+                1,
+                currentWorkoutId
+            )
+            val prevText = latest?.let { formatPrevious(it.weight, it.reps) }
+            setPreviousForOneSet(exercise.exerciseId, 1, prevText)
+        }
+
         // Create the Workout + ExerciseLog lazily (so it’s ready for set saving)
         viewModelScope.launch {
             val workoutId = ensureWorkoutExists()
@@ -169,6 +179,21 @@ class ActiveWorkoutViewModel(private val appContext: Context) : ViewModel() {
             }
         }
         _activeExercises.value = updated
+
+        val newSetNumber = updated
+            .first { it.exerciseId == exerciseId }
+            .sets
+            .maxOf { it.setNumber }
+
+        viewModelScope.launch {
+            val latest = performedSetDao.getLatestSetForExerciseAndNumberExcludingWorkout(
+                exerciseId,
+                newSetNumber,
+                currentWorkoutId
+            )
+            val prevText = latest?.let { formatPrevious(it.weight, it.reps) }
+            setPreviousForOneSet(exerciseId, newSetNumber, prevText)
+        }
     }
 
     fun removeSet(exerciseId: Long, setNumber: Int) {
@@ -306,6 +331,32 @@ class ActiveWorkoutViewModel(private val appContext: Context) : ViewModel() {
                     return ActiveWorkoutViewModel(context.applicationContext) as T
                 }
             }
+        }
+    }
+
+    private fun setPreviousForExercise(exerciseId: Long, previousText: String?) {
+        _activeExercises.value = _activeExercises.value.map { ex ->
+            if (ex.exerciseId != exerciseId) ex
+            else ex.copy(
+                sets = ex.sets.map { s ->
+                    // Sæt "previous" for alle sets (eller kun set 1 hvis du vil)
+                    s.copy(previous = previousText)
+                }
+            )
+        }
+    }
+
+    private fun formatPrevious(weight: Float, reps: Int): String =
+        "${weight.toInt()} kg x $reps"
+
+    private fun setPreviousForOneSet(exerciseId: Long, setNumber: Int, previousText: String?) {
+        _activeExercises.value = _activeExercises.value.map { ex ->
+            if (ex.exerciseId != exerciseId) ex
+            else ex.copy(
+                sets = ex.sets.map { s ->
+                    if (s.setNumber == setNumber) s.copy(previous = previousText) else s
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
Adds a new query to `PerformedSetDao` to fetch the latest performed set for a specific exercise and set number, excluding the current workout.

In `ActiveWorkoutViewModel`, this new query is used to display the weight and reps from the last time the user performed the same set number for an exercise. This "previous" data is shown when an exercise is first added and when a new set is added.